### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ up from the following:
 * [perp](http://b0llix.net/perp/) (process supervisor)
 * [pigz](http://zlib.net/pigz/) (gzip)
 * [tz](https://www.iana.org/time-zones)
-* util-linux (for fdisk)
+* util-linux
 * [xz](http://tukaani.org/xz/)


### PR DESCRIPTION
util-linux it's huge package with lots of vital tools (
addpart
agetty
blkdiscard
blkid
blockdev
cal
cfdisk
chcpu
chfn
chrt
chsh
col (legacy)[5]
colcrt
colrm
column
ctrlaltdel
delpart
dmesg
eject
fallocate
fdformat
fdisk
findfs
findmnt
flock
fsck
fsck.cramfs
fsck.minix
fsfreeze
fstab
fstrim
getopt
hexdump
hwclock (query and set the hardware clock (RTC))
ionice
ipcmk
ipcrm
ipcs
isosize
kill
last
ldattach
line (legacy)[5]
logger
login
look
losetup
lsblk
lscpu[6]
lslocks
lslogins
mcookie
mesg
mkfs (legacy)[5]
mkfs.bfs
mkfs.cramfs
mkfs.minix
mkswap
more
mount
mountpoint
namei
newgrp
nologin
nsenter
partx
pg (legacy)[5]
pivot_root
prlimit[7]
raw
readprofile
rename
renice
reset (legacy)[5]
resizepart
rev
RTC Alarm
runuser
script
scriptreplay
setarch (including architecture symlinks such as i386, linux32, linux64, x86_64, etc.)
setpriv
setsid
setterm
sfdisk
su
sulogin
swaplabel
swapoff
swapon
switch_root
tailf (legacy)[5]
taskset
tunelp (deprecated)[8]
ul
umount
unshare
utmpdump
uuidd
uuidgen
vipw (including symlink to vigr)
wall
wdctl
whereis
wipefs
write
zramct}

fdisk is only small part, so it's better remove this string to not confuse people.