### PR TITLE
strace: aarch64 support

### DIFF
--- a/pkg/strace/config.h
+++ b/pkg/strace/config.h
@@ -226,7 +226,9 @@
 #define HAVE_STRUCT_IOCB_AIO_RW_FLAGS 1
 #define HAVE_STRUCT_KBDIACRSUC 1
 #define HAVE_STRUCT_KBDIACRUC 1
+#if __x86_64__
 #define HAVE_STRUCT_KVM_CPUID2 1
+#endif /* __x86_64__ */
 #define HAVE_STRUCT_KVM_REGS 1
 #define HAVE_STRUCT_KVM_RUN_FLAGS 1
 #define HAVE_STRUCT_KVM_RUN_IMMEDIATE_EXIT 1
@@ -263,13 +265,17 @@
 #define HAVE_STRUCT_TERMIOS2 1
 /* #undef HAVE_STRUCT_TERMIOS_C_ISPEED */
 /* #undef HAVE_STRUCT_TERMIOS_C_OSPEED */
+#if __x86_64__
 #define HAVE_STRUCT_USER_DESC 1
 #define HAVE_STRUCT_USER_DESC_LM 1
+#endif /* __x86_64__ */
 #define HAVE_STRUCT_UTSNAME_DOMAINNAME 1
 /* #undef HAVE_STRUCT___AIO_SIGSET */
 #define HAVE_STRUCT___KERNEL_SOCK_TIMEVAL 1
 #define HAVE_STRUCT___KERNEL_TIMESPEC 1
+#if __x86_64__
 #define HAVE_STRUCT___OLD_KERNEL_STAT 1
+#endif /* __x86_64__ */
 #define HAVE_SYNC_FILE_RANGE 1
 #define HAVE_SYS_EVENTFD_H 1
 #define HAVE_SYS_FANOTIFY_H 1
@@ -590,9 +596,7 @@
 # endif
 #endif
 /* #undef X32 */
-#ifdef __x86_64__
-# define X86_64 1
-#endif
+/* #undef X86_64 */
 /* #undef XTENSA */
 /* #undef gid_t */
 /* #undef typeof */

--- a/pkg/strace/gen.lua
+++ b/pkg/strace/gen.lua
@@ -1,13 +1,27 @@
+local targets = {
+	aarch64={
+		cflags={'-D AARCH64=1'},
+		ioctl_inc_count=1,
+	},
+	x86_64={
+		cflags={'-D X86_64=1'},
+		ioctl_inc_count=2,
+	},
+}
+local arch = config.target.platform:match('[^-]*')
+if not targets[arch] then return end
+
 cflags{
 	'-D HAVE_CONFIG_H',
 	'-D IN_STRACE',
 	-- it is important that the arch-specific directory is searched first
-	'-I $srcdir/src/linux/x86_64',
+	'-I $srcdir/src/linux/'..arch,
 	'-I $srcdir/src/linux/generic',
 	'-I $srcdir/src',
 	'-I $outdir',
 	'-isystem $builddir/pkg/linux-headers/include',
 }
+cflags(targets[arch].cflags)
 
 build('cat', '$outdir/config.h', {
 	'$builddir/probe/HAVE___BUILTIN_POPCOUNT',
@@ -22,16 +36,16 @@ build('sed', '$outdir/ioctl_iocdef.h', '$outdir/ioctl_iocdef.i', {
 sub('tools.ninja', function()
 	toolchain(config.host)
 	cflags{
-		'-D X86_64=1',
-		'-I $srcdir/src/linux/x86_64',
+		'-I $srcdir/src/linux/'..arch,
 		'-I $srcdir/src/linux',
 		'-I $outdir',
 	}
+	cflags(targets[arch].cflags)
 
-	for i = 0, 2 do
+	for i = 0, targets[arch].ioctl_inc_count do
 		build('cat', '$outdir/ioctls_all'..i..'.h', {
-			'$srcdir/src/linux/x86_64/ioctls_inc'..i..'.h',
-			'$srcdir/src/linux/x86_64/ioctls_arch'..i..'.h',
+			'$srcdir/src/linux/'..arch..'/ioctls_inc'..i..'.h',
+			'$srcdir/src/linux/'..arch..'/ioctls_arch'..i..'.h',
 		})
 		build('cc', '$outdir/ioctlsort'..i..'.c.o', {
 			'$srcdir/src/ioctlsort.c',
@@ -379,9 +393,6 @@ build('sed', '$outdir/sys_func.h', expand{'$srcdir/', srcs}, {
 
 pkg.deps = {
 	'$outdir/config.h',
-	'$outdir/ioctlent0.h',
-	'$outdir/ioctlent1.h',
-	'$outdir/ioctlent2.h',
 	'$outdir/native_printer_decls.h',
 	'$outdir/native_printer_defs.h',
 	'$outdir/printers.h',
@@ -390,6 +401,10 @@ pkg.deps = {
 	'$outdir/sys_func.h',
 	'pkg/linux-headers/headers',
 }
+
+for i = 0, targets[arch].ioctl_inc_count do
+	table.insert(pkg.deps, '$outdir/ioctlent'..i..'.h')
+end
 
 lib('libstrace.a', srcs)
 exe('strace', {'src/strace.c', 'libstrace.a'})


### PR DESCRIPTION
Hi, I've recently acquired an aarch64 laptop and wanted to use strace on it. While I was at it I bumped the version. This requires the linux-headers bump, #130, as well.

There are still a few packages that don't build on aarch64 - python, ffmpeg, and dav1d. If I have the time I will look into them as well.